### PR TITLE
add slack signup email

### DIFF
--- a/aboutMe.yml
+++ b/aboutMe.yml
@@ -3,6 +3,6 @@ studentNumber: Tuesday
 gitHubUsername: HarleyT
 stackoverflow: http://stackoverflow.com/users/7645501/harleyt
 mediumUsername: harley.t
-unswEmail: noIdea@unsw.edu.au
+unswEmail: harley.trappitt@arup.com
 realEmailFirstBit: harley.trappitt  # this avoids spam
 realEmailOtherBit: @gmail.com


### PR DESCRIPTION
You used your arup email to sign up to slack, so I need it in there somewhere